### PR TITLE
feat: edge function now retrieves stream guest info

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "deno.enable": true,
+  "deno.enablePaths": ["netlify/edge-functions"],
+  "deno.unstable": true,
+  "deno.importMap": ".netlify/edge-functions-import-map.json"
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,6 @@
 [build]
   publish = "public/"
+
+[[edge_functions]]
+function = "stream-guest-info"
+path = "/stream-guest-info"

--- a/netlify/edge-functions/stream-guest-info/stream-guest-info.ts
+++ b/netlify/edge-functions/stream-guest-info/stream-guest-info.ts
@@ -9,10 +9,13 @@ async function getStreamGuestUrl(streamDate: string) {
   const filterByFormula = encodeURIComponent(
     `AND(DATESTR({Date}) = "${streamDate}")`,
   );
+
+  // Generates querystring key value pairs that look like this, Name&fields[]=Guest%20Title&fields[]=Stream%20Title
   const fields = ['Name', 'Guest Title', 'Stream Title']
     .map(encodeURIComponent)
     .join('&fields[]=');
 
+  // Uses the Airtable API's filterByFormula (see https://support.airtable.com/docs/how-to-sort-filter-or-retrieve-ordered-records-in-the-api)
   const streamGuestInfoQueryUrl = `https://api.airtable.com/v0/${AIRTABLE_STREAM_GUEST_BASE_ID}/Stream%20Guests?filterByFormula=${filterByFormula}&fields[]=${fields}`;
   const response = await fetch(streamGuestInfoQueryUrl, {
     headers: {
@@ -25,6 +28,7 @@ async function getStreamGuestUrl(streamDate: string) {
   let redirectUrl;
 
   if (records.length === 0) {
+    // If for some reason there is no record for the day of the stream, this URL will tell me when it loads in OBS
     redirectUrl = 'https://streamtastic.netlify.app/background.html';
   } else {
     const streamGuestInfo = records[0]?.fields;

--- a/netlify/edge-functions/stream-guest-info/stream-guest-info.ts
+++ b/netlify/edge-functions/stream-guest-info/stream-guest-info.ts
@@ -1,0 +1,59 @@
+import type { Context } from 'https://edge.netlify.com';
+
+const AIRTABLE_API_KEY = Deno.env.get('AIRTABLE_API_KEY');
+const AIRTABLE_STREAM_GUEST_BASE_ID = Deno.env.get(
+  'AIRTABLE_STREAM_GUEST_BASE_ID',
+);
+
+async function getStreamGuestUrl(streamDate: string) {
+  const filterByFormula = encodeURIComponent(
+    `AND(DATESTR({Date}) = "${streamDate}")`,
+  );
+  const fields = ['Name', 'Guest Title', 'Stream Title']
+    .map(encodeURIComponent)
+    .join('&fields[]=');
+
+  const streamGuestInfoQueryUrl = `https://api.airtable.com/v0/${AIRTABLE_STREAM_GUEST_BASE_ID}/Stream%20Guests?filterByFormula=${filterByFormula}&fields[]=${fields}`;
+  const response = await fetch(streamGuestInfoQueryUrl, {
+    headers: {
+      Authorization: `Bearer ${AIRTABLE_API_KEY}`,
+    },
+  });
+
+  const { records } = await response.json();
+
+  let redirectUrl;
+
+  if (records.length === 0) {
+    redirectUrl = 'https://streamtastic.netlify.app/background.html';
+  } else {
+    const streamGuestInfo = records[0]?.fields;
+    const encodedStreamTitle = encodeURIComponent(
+      streamGuestInfo['Stream Title'],
+    );
+    const encodedGuestTitle = encodeURIComponent(
+      `${streamGuestInfo.Name}, ${streamGuestInfo['Guest Title']}`,
+    );
+
+    redirectUrl = `/background.html?title=${encodedStreamTitle}&guest=${encodedGuestTitle}`;
+  }
+
+  return redirectUrl;
+}
+
+export default async (_request: Request, context: Context) => {
+  const today = new Date();
+  const streamDate = today.toISOString().slice(0, 10);
+  const redirectUrl = await getStreamGuestUrl(streamDate);
+
+  context.log('Guest stream info redirect URL', redirectUrl);
+
+  return new Response('The request to this URL was logged', {
+    status: 302,
+    headers: {
+      Location: redirectUrl,
+      // Cache for two minutes in case I need to adjust the guest info before a stream
+      'Cache-Control': 'max-age=120',
+    },
+  });
+};


### PR DESCRIPTION
## Description

Adds a Netlify Edge function to retrieve a stream guest's info for the iamdeveloper.live stream.

* Use a Netlify Edge function to retrieve the guest's info from Airtable and then generate a redirect URL to e.g. `https://streamtastic.netlify.app/background.html?title=Some+Awesome+Title&guest=Some+Awesome+Guest`
* Caches the redirect for a couple of minutes since I may need to change the guest's info close to the stream time
* Use AirTable's [REST API](https://support.airtable.com/v1/docs/api)
* The path to the Edge function is `/stream-guest-info`

## Test

Navigate to https://deploy-preview-3--streamtastic.netlify.app/stream-guest-info. If there is no guest info for the day you are reviewing this PR the page will redirect to https://streamtastic.netlify.app/background.html.

![CleanShot 2022-11-06 at 14 03 37](https://user-images.githubusercontent.com/833231/200189963-a441ef93-a9fa-422d-826d-56f9b4d95960.png)

Add some guest info for the day this is being reviewed, and as long as two minutes has passed since the guest info was added, you will see the following with some guest info

![CleanShot 2022-11-06 at 14 05 31](https://user-images.githubusercontent.com/833231/200190043-4a165d86-6eec-47a2-8025-4d624b91df57.png)

## Issues & Related Documents

Closes #2

